### PR TITLE
Update README with require syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ To see all endpoint available take a look at [instagram developer documentation]
 
 ```javascript
 import Instagram from 'node-instagram';
+// or
+const Instagram = require('node-instagram').default;
+
 
 // Create a new instance.
 const instagram = new Instagram({


### PR DESCRIPTION
Great module! I'm a big fan of the promise support.

This is a small change to include the `require` syntax for importing this module:
```js
const Instagram = require('node-instagram').default
```

The inclusion of `default` was new to me and I wanted to help anyone else not using a module bundler save a few minutes of googling.