### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,67 +122,67 @@ To see all endpoint available take a look at [instagram developer documentation]
 
 ```javascript
 // Get information about current user
-instagram.get('users/self', (err, data) => {
+instagram.get('users/self', { access_token: accessToken }, (err, data) => {
   console.log(data);
 });
 
 // Get information about a user.
-instagram.get('users/:user-id').then((data) => {
+instagram.get('users/:user-id', { access_token: accessToken }).then((data) => {
   console.log(data);
 });
 
 // Get the most recent media published by the owner of the access_token.
-instagram.get('users/self/media/recent').then((data) => {
+instagram.get('users/self/media/recent', { access_token: accessToken }).then((data) => {
   console.log(data);
 });
 
 // Get the most recent media published by a user.
-instagram.get('users/:user-id/media/recent').then((data) => {
+instagram.get('users/:user-id/media/recent', { access_token: accessToken }).then((data) => {
   console.log(data);
 });
 
 // Get the list of recent media liked by the owner of the access_token.
-instagram.get('users/self/media/liked').then((data) => {
+instagram.get('users/self/media/liked', { access_token: accessToken }).then((data) => {
   console.log(data);
 });
 
 // Get a list of users matching the query.
-instagram.get('users/search', { q: 'paris' }).then((data) => {
+instagram.get('users/search', { access_token: accessToken, q: 'paris' }).then((data) => {
   console.log(data);
 });
 
 // Get information about this media.
-instagram.get('media/:media-id').then((data) => {
+instagram.get('media/:media-id', { access_token: accessToken }).then((data) => {
   console.log(data);
 });
 
 // Get a list of users who have liked this media.
-instagram.get('media/:media-id/likes').then((data) => {
+instagram.get('media/:media-id/likes', { access_token: accessToken }).then((data) => {
   console.log(data);
 });
 
 // Set a like on this media by the currently authenticated user.
-instagram.post('media/:media-id/likes').then((data) => {
+instagram.post('media/:media-id/likes', { access_token: accessToken }).then((data) => {
   console.log(data);
 });
 
 // Remove a like on this media by the currently authenticated user.
-instagram.delete('media/:media-id/likes').then((data) => {
+instagram.delete('media/:media-id/likes', { access_token: accessToken }).then((data) => {
   console.log(data);
 });
 
 // Get information about a tag object.
-instagram.get('tags/:tag-name').then((data) => {
+instagram.get('tags/:tag-name', { access_token: accessToken }).then((data) => {
   console.log(data);
 });
 
 // Get a list of recently tagged media.
-instagram.get('tags/:tag-name/media/recent').then((data) => {
+instagram.get('tags/:tag-name/media/recent', { access_token: accessToken }).then((data) => {
   console.log(data);
 });
 
 // Search for tags by name.
-instagram.get('tags/search', { q: 'paris' }).then((data) => {
+instagram.get('tags/search', { access_token: accessToken, q: 'paris' }).then((data) => {
   console.log(data);
 });
 ```


### PR DESCRIPTION
I thought it might be a good idea to explain in the examples that you can (and in my experience, have to, but I could be wrong) send the acces_token along as a parameter when you call an endpoint. When I first tried doing it as explained in the README I got stuck because it expected you to provide an access token when creating the `Instagram` instance. Yet, first you have to get an access_token from the user, and to get this, you already need to have an instance of `Instagram` so that you can call `instagram.getAuthorizationUrl`. Putting the access_token in the endpoint examples might help people understand this process better.