### PR TITLE
Make accessToken optional in InstagramConfig

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import Stream from './stream';
 export interface InstagramConfig {
   clientId: string;
   clientSecret: string;
-  accessToken: string;
+  accessToken?: string;
   apiVersion?: string;
 }
 


### PR DESCRIPTION
Currently theres a Typescript warning if accessToken isn't provided. Like in this example https://github.com/pradel/node-instagram/blob/master/examples/express-auth/index.js.